### PR TITLE
chore(lefthook): rename PR branch "hook" more descriptively

### DIFF
--- a/.config/lefthook.yaml
+++ b/.config/lefthook.yaml
@@ -3,7 +3,7 @@ commit-msg:
     committed:
       run: mise exec -- committed --config=.config/committed.toml --fixup --wip --commit-file="{1}"
 
-commit-msgs-on-pr-branch:
+commits-on-pr-branch:
   commands:
     committed:
       run: mise exec -- committed --config=.config/committed.toml -vv --no-merge-commit HEAD~..HEAD^2


### PR DESCRIPTION
It checks more from commits than just messages. commit-msg needs to stay like that to actually work though (it being a real git hook).